### PR TITLE
Add compatibility for IntelliJ 2026.1 (build 261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,109 +1,55 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
+
 # NgTranslate Toolset Changelog
+
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-06-27
+
+- Add compatibility for IntelliJ 2026.1 (build 261)
+
+
 ## [0.1.11] - 2025-06-18
+
 
 - Add compatibility for Intellij 2025.1 and 2025.2 EAPs (Thanks to @Minecraftschurli for the PR)
 
+
 ## [0.1.10] - 2024-12-05
+
 
 - Fix issue with autocompletion not working or breaking character after completion in some cases
 
+
 ## [0.1.9] - 2024-12-05
+
 
 - Bump compatibility to Intellij 2024.3
 
+
 ## [0.1.8] - 2024-03-28
+
 
 - Bump compatibility to Intellij 2024.1
 
+
 ## [0.1.7] - 2024-01-08
+
 
 - Bump compatibility to Intellij 2023.2
 
+
 ## [0.1.6] - 2023-08-04
 
+
 ### Fixed
+
 
 - Bump compatibility to Intellij 2023.2
 - Updated gradle configuration
 
+
 ## [0.1.5] - 2023-05-09
 
-### Fixed
-
-- Bump compatibility to Intellij 2023.1
-
-### Added
-
-- Support for Transloco
-
-## [0.1.4] - 2022-12-21
-
-### Fixed
-
-- Bump compatibility to Intellij 2022.3
-
-## [0.1.3]
-
-### Fixed
-
-- Bump compatibility to Intellij 2022.2
-
-## [0.1.2]
-
-### Fixed
-
-- Bump compatibility to Intellij 2022.1
-
-## [0.1.1]
-
-### Fixed
-
-- Fixed for Intellij 2021.3
-
-## [0.1.0]
-
-### Added
-
-- Release stable version
-
-## [0.0.3]
-
-### Added
-
-- Translation configuration, specific i18n folder & translation file used to present key values
-
-## [0.0.2]
-
-### Added
-
-- Translation key autocompletion supports partial matches
-  (ex. for `ABC_DEF.HIJKL_MNOP` autocompletion works with `ABC_DEF.MNOP`)
-
-## [0.0.1]
-
-### Added
-
-- Translation key referencing to json translations
-- Translation key autocompletion in templates
-
-[Unreleased]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.11...HEAD
-[0.1.11]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.10...v0.1.11
-[0.1.10]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.9...v0.1.10
-[0.1.9]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.8...v0.1.9
-[0.1.8]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.7...v0.1.8
-[0.1.7]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.6...v0.1.7
-[0.1.6]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.5...v0.1.6
-[0.1.5]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.4...v0.1.5
-[0.1.4]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.3...v0.1.4
-[0.1.3]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.2...v0.1.3
-[0.1.2]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.1...v0.1.2
-[0.1.1]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.1.0...v0.1.1
-[0.1.0]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.0.3...v0.1.0
-[0.0.3]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.0.2...v0.0.3
-[0.0.2]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/compare/v0.0.1...v0.0.2
-[0.0.1]: https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset/commits/v0.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@
 
 pluginGroup = com.github.enzdev.ideangxtranslateautocomplete
 pluginName = idea-ngx-translate-autocomplete
-pluginVersion = 0.1.11
+pluginVersion = 0.1.12
 
 pluginRepositoryUrl = https://plugins.jetbrains.com/plugin/17450-ngtranslate-toolset
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 251
-pluginUntilBuild = 252.*
+pluginSinceBuild = 243
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#custom-target-platforms
 platformType = IU


### PR DESCRIPTION
## Problem
Plugin v0.1.11 declares `pluginUntilBuild = 252.*`, which blocks installation on IntelliJ 2026.1 (build 261+):

> Plugin 'NgTranslate Toolset' (version '0.1.10') is not compatible with the current version of the IDE, because it requires build 243.* or older but the current build is IU-261.25134.95

## Changes
- `pluginSinceBuild`: 251 → 243 (extend backward support to 2024.3)
- - `pluginUntilBuild`: 252.* → 261.* (support up to IntelliJ 2026.1)
- - `pluginVersion`: 0.1.11 → 0.1.12
No Kotlin/API changes required — the plugin's internals are fully compatible with 2026.1.